### PR TITLE
Add compatibility for Lootr.

### DIFF
--- a/src/main/java/artifacts/common/world/CampsiteFeature.java
+++ b/src/main/java/artifacts/common/world/CampsiteFeature.java
@@ -133,10 +133,7 @@ public class CampsiteFeature extends Feature<NoFeatureConfig> {
             } else {
                 setBlockState(world, pos, Blocks.BARREL.getDefaultState().with(BarrelBlock.PROPERTY_FACING, Direction.getRandomDirection(random)));
             }
-            TileEntity container = world.getTileEntity(pos);
-            if (container instanceof LockableLootTileEntity) {
-                ((LockableLootTileEntity) container).setLootTable(LootTables.CAMPSITE_CHEST, random.nextLong());
-            }
+            LockableLootTileEntity.setLootTable(world, random, pos, LootTables.CAMPSITE_CHEST);
         }
     }
 


### PR DESCRIPTION
This patch simply switches to the LockableLootTileEntity's static `setLootTable` method instead of directly accessing the tile entity and calling it there.

This provides compatibility with Lootr, a mod that provides instanced loot, per-chest, per-player, for multiplayer servers. Unfortunately, I can't hook into the member `setLootTable` as the world will either be null or not be the relevant world-generation world.

Switching to the static method means the world-generation world instance is passed in and that can be hooked into to provide replacements without causing crashes or deadlocks.

Code-wise, the static method acts identically to the currently used method, meaning there is no actual functional change.