### PR TITLE
Fix missing injected loot tables

### DIFF
--- a/src/main/java/artifacts/common/init/ModLootTables.java
+++ b/src/main/java/artifacts/common/init/ModLootTables.java
@@ -31,6 +31,8 @@ public class ModLootTables {
                 "chests/village/village_desert_house",
                 "chests/village/village_plains_house",
                 "chests/village/village_savanna_house",
+                "chests/village/village_snowy_house.json",
+                "chests/village/village_taiga_house.json",
                 "chests/abandoned_mineshaft",
                 "chests/bastion_hoglin_stable",
                 "chests/bastion_treasure",


### PR DESCRIPTION
Two loot tables added in https://github.com/ochotonida/artifacts/commit/438a5a2f29dd73b64777fa2f141495717ccdca45