### PR TITLE
[1.15.2] Fixed adding empty nbt tag to item in hand by FortuneModifier while breaking blocks

### DIFF
--- a/src/main/java/artifacts/common/item/LuckyScarfItem.java
+++ b/src/main/java/artifacts/common/item/LuckyScarfItem.java
@@ -68,7 +68,7 @@ public class LuckyScarfItem extends ArtifactItem {
         protected List<ItemStack> doApply(List<ItemStack> generatedLoot, LootContext context) {
             ItemStack tool = context.get(LootParameters.TOOL);
 
-            if (tool == null || tool.getOrCreateTag().getBoolean("HasAppliedFortuneBonus")) {
+            if (tool == null || (tool.hasTag() && tool.getTag().getBoolean("HasAppliedFortuneBonus"))) {
                 return generatedLoot;
             }
 


### PR DESCRIPTION
So, I faced this problem, when I used Artifacts with Project MMO mod. But some other mods may also cause the same problem.

When you break block with any item in the main hand, PMMO puts it in LootContextBuilder: https://github.com/Harmonised7/project_mmo/blob/8724ccc658bd45ca6d648313caf22ee01a0701b0/src/main/java/harmonised/pmmo/events/BlockBrokenHandler.java#L192
Then, in LuckyScarfItem you retrieve this item from the context. https://github.com/ochotonida/artifacts/blob/6f0d23bf60ff09c9f41ff7be36cb5ea48b9dcc61/src/main/java/artifacts/common/item/LuckyScarfItem.java#L69
And then you call `getOrCreateTag()` for this item, which sets the empty NBT Tag to it, if it doesn't have it. https://github.com/ochotonida/artifacts/blob/6f0d23bf60ff09c9f41ff7be36cb5ea48b9dcc61/src/main/java/artifacts/common/item/LuckyScarfItem.java#L71

So I fixed it by replacing `getOrCreateTag()` with extra check for item having a tag.