### PR TITLE
Effects of the crystal heart and charm of sinking should always be disabled when unequipped

### DIFF
--- a/src/main/java/artifacts/common/item/curio/belt/CrystalHeartItem.java
+++ b/src/main/java/artifacts/common/item/curio/belt/CrystalHeartItem.java
@@ -44,7 +44,7 @@ public class CrystalHeartItem extends CurioItem {
 
     @Override
     public void onUnequip(SlotContext slotContext, ItemStack originalStack, ItemStack newStack) {
-        if (!ModConfig.server.isCosmetic(this) && !slotContext.getWearer().level.isClientSide()) {
+        if (!slotContext.getWearer().level.isClientSide()) {
             ModifiableAttributeInstance health = slotContext.getWearer().getAttribute(Attributes.MAX_HEALTH);
             AttributeModifier healthBonus = getHealthBonus();
             if (health != null && health.hasModifier(healthBonus)) {

--- a/src/main/java/artifacts/common/item/curio/necklace/CharmOfSinkingItem.java
+++ b/src/main/java/artifacts/common/item/curio/necklace/CharmOfSinkingItem.java
@@ -45,7 +45,7 @@ public class CharmOfSinkingItem extends CurioItem {
 
     @Override
     public void onUnequip(SlotContext slotContext, ItemStack originalStack, ItemStack newStack) {
-        if (!ModConfig.server.isCosmetic(this) && slotContext.getWearer() instanceof ServerPlayerEntity) {
+        if (slotContext.getWearer() instanceof ServerPlayerEntity) {
             slotContext.getWearer().getCapability(SwimHandlerCapability.INSTANCE).ifPresent(
                     handler -> {
                         handler.setSinking(false);


### PR DESCRIPTION
Disable effect on unequip regardless of cosmetic config. Might otherwise be possible to get stuck with effects enabled.