### PR TITLE
Added config values for min_y and max_y

### DIFF
--- a/src/main/java/artifacts/common/config/CommonConfig.java
+++ b/src/main/java/artifacts/common/config/CommonConfig.java
@@ -18,6 +18,8 @@ public class CommonConfig {
     private final ForgeConfigSpec.ConfigValue<List<String>> biomeBlacklist;
     public final ForgeConfigSpec.IntValue campsiteRarity;
     public final ForgeConfigSpec.DoubleValue campsiteMimicChance;
+    public final ForgeConfigSpec.IntValue campsiteMinY;
+    public final ForgeConfigSpec.IntValue campsiteMaxY;
     public final ForgeConfigSpec.BooleanValue useModdedChests;
     public final ForgeConfigSpec.DoubleValue artifactRarity;
 
@@ -55,6 +57,20 @@ public class CommonConfig {
                 )
                 .translation(Artifacts.MODID + ".config.common.campsite.rarity")
                 .defineInRange("rarity", 5, 1, 10000);
+        campsiteMinY = builder
+                .worldRestart()
+                .comment(
+                        "Minimum Y-coordinate height for a campsite to generate"
+                )
+                .translation(Artifacts.MODID + ".config.common.campsite.min_y")
+                .defineInRange("min_y", 32, -2048, 2048);
+        campsiteMaxY = builder
+                .worldRestart()
+                .comment(
+                        "Maximum Y-coordinate height for a campsite to generate"
+                )
+                .translation(Artifacts.MODID + ".config.common.campsite.max_y")
+                .defineInRange("max_y", 96, -2048, 2048);
         campsiteMimicChance = builder
                 .comment("Probability that a campsite has a mimic instead of a chest")
                 .translation(Artifacts.MODID + ".config.common.campsite.mimic_chance")

--- a/src/main/java/artifacts/common/init/ModFeatures.java
+++ b/src/main/java/artifacts/common/init/ModFeatures.java
@@ -48,8 +48,8 @@ public class ModFeatures {
                                 RarityFilter.onAverageOnceEvery(ModConfig.common.campsiteRarity.get()),
                                 InSquarePlacement.spread(),
                                 HeightRangePlacement.uniform(
-                                         VerticalAnchor.aboveBottom(32),
-                                         VerticalAnchor.aboveBottom(96)
+                                         VerticalAnchor.aboveBottom(ModConfig.common.campsiteMinY.get()),
+                                         VerticalAnchor.aboveBottom(ModConfig.common.campsiteMaxY.get())
                                 ),
                                 EnvironmentScanPlacement.scanningFor(Direction.DOWN, BlockPredicate.solid(), BlockPredicate.ONLY_IN_AIR_PREDICATE, 32),
                                 RandomOffsetPlacement.vertical(ConstantInt.of(1)),


### PR DESCRIPTION
Make the minimum and maximum height for campsites to generate
configurable in the common config.

The translation strings for this already existed 😄 

Fixes #143