### PR TITLE
Improve performance of `PlatformHelper#findAllEquippedBy`

### DIFF
--- a/fabric/src/main/java/artifacts/fabric/platform/FabricPlatformHelper.java
+++ b/fabric/src/main/java/artifacts/fabric/platform/FabricPlatformHelper.java
@@ -37,22 +37,18 @@ import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 public class FabricPlatformHelper implements PlatformHelper {
 
     @Override
     public Stream<ItemStack> findAllEquippedBy(LivingEntity entity, Predicate<ItemStack> predicate) {
-        List<ItemStack> armor = new ArrayList<>(4);
-        for (ItemStack stack : entity.getArmorAndBodyArmorSlots()) {
-            if (predicate.test(stack)) {
-                armor.add(stack);
-            }
-        }
+        Stream<ItemStack> armor = StreamSupport.stream(entity.getArmorAndBodyArmorSlots().spliterator(), false).filter(predicate);
 
         if (FabricLoader.getInstance().isModLoaded("trinkets")) {
-            return Stream.concat(TrinketsIntegration.findAllEquippedBy(entity).filter(predicate), armor.stream());
+            return Stream.concat(TrinketsIntegration.findAllEquippedBy(entity).filter(predicate), armor);
         }
-        return armor.stream();
+        return armor;
     }
 
     @Override

--- a/neoforge/src/main/java/artifacts/neoforge/platform/NeoForgePlatformHelper.java
+++ b/neoforge/src/main/java/artifacts/neoforge/platform/NeoForgePlatformHelper.java
@@ -35,21 +35,17 @@ import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 public class NeoForgePlatformHelper implements PlatformHelper {
 
     @Override
     public Stream<ItemStack> findAllEquippedBy(LivingEntity entity, Predicate<ItemStack> predicate) {
-        List<ItemStack> armor = new ArrayList<>(4);
-        for (ItemStack stack : entity.getArmorAndBodyArmorSlots()) {
-            if (predicate.test(stack)) {
-                armor.add(stack);
-            }
-        }
+        Stream<ItemStack> armor = StreamSupport.stream(entity.getArmorAndBodyArmorSlots().spliterator(), false).filter(predicate);
         if (ModList.get().isLoaded("curios")) {
-            return Stream.concat(CuriosIntegration.findAllEquippedBy(entity, predicate), armor.stream());
+            return Stream.concat(CuriosIntegration.findAllEquippedBy(entity, predicate), armor);
         }
-        return armor.stream();
+        return armor;
     }
 
     @Override


### PR DESCRIPTION
- Changed the creation of a list each tick on every entity to use a stream based implementation instead.

When tested in single-player with ~1100 entities (mostly chickens) on NeoForge, there was a ~20ms difference in the ms it takes to tick. This has also been tested on a heavily modded NeoForge server where the old code was a major lag problem, running at 10tps when having 1100 entities in the world to around 17tps.