### PR TITLE
Fix Obsidian Skull effect not fired when player is wearing any armor

### DIFF
--- a/common/src/main/java/artifacts/ability/mobeffect/ApplyMobEffectAfterDamageAbility.java
+++ b/common/src/main/java/artifacts/ability/mobeffect/ApplyMobEffectAfterDamageAbility.java
@@ -45,7 +45,7 @@ public record ApplyMobEffectAfterDamageAbility(Holder<MobEffect> mobEffect, Valu
 
     public static void onLivingDamaged(LivingEntity entity, DamageSource damageSource, float amount) {
         if (!entity.level().isClientSide()
-                && amount >= 1
+                && amount >= 0.1
         ) {
             AbilityHelper.forEach(ModAbilities.APPLY_MOB_EFFECT_AFTER_DAMAGE.value(), entity, (ability, stack) -> {
                 if (ability.tag().isEmpty() || damageSource.is(ability.tag().get())) {


### PR DESCRIPTION
When player is wearing any armor, the lava/fire damage amount can be less than 1, and fire resistance not gained. However, the item cooldown functions correctry.

I have tested using netherite armor with Fire Protection IV and ensured it works correctly.